### PR TITLE
Add GitHub Releases Feature

### DIFF
--- a/app/src/components/layout.tsx
+++ b/app/src/components/layout.tsx
@@ -35,6 +35,9 @@ export function Layout({ children }: PropsWithChildren) {
         ></label>
         <ul className="menu bg-base-200 text-base-content min-h-full w-80 p-4 gap-2">
           <li>
+            <Link to="/overview">Overview</Link>
+          </li>
+          <li>
             <Link to="/metrics">Metrics</Link>
           </li>
           <li>

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -16,12 +16,19 @@ import { Route as rootRoute } from './routes/__root'
 
 // Create Virtual Routes
 
+const OverviewLazyImport = createFileRoute('/overview')()
 const MetricsLazyImport = createFileRoute('/metrics')()
 const IssuesLazyImport = createFileRoute('/issues')()
 const FuncSpecsLazyImport = createFileRoute('/func-specs')()
 const DependenciesLazyImport = createFileRoute('/dependencies')()
 
 // Create/Update Routes
+
+const OverviewLazyRoute = OverviewLazyImport.update({
+  id: '/overview',
+  path: '/overview',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/overview.lazy').then((d) => d.Route))
 
 const MetricsLazyRoute = MetricsLazyImport.update({
   id: '/metrics',
@@ -79,6 +86,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MetricsLazyImport
       parentRoute: typeof rootRoute
     }
+    '/overview': {
+      id: '/overview'
+      path: '/overview'
+      fullPath: '/overview'
+      preLoaderRoute: typeof OverviewLazyImport
+      parentRoute: typeof rootRoute
+    }
   }
 }
 
@@ -89,6 +103,7 @@ export interface FileRoutesByFullPath {
   '/func-specs': typeof FuncSpecsLazyRoute
   '/issues': typeof IssuesLazyRoute
   '/metrics': typeof MetricsLazyRoute
+  '/overview': typeof OverviewLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -96,6 +111,7 @@ export interface FileRoutesByTo {
   '/func-specs': typeof FuncSpecsLazyRoute
   '/issues': typeof IssuesLazyRoute
   '/metrics': typeof MetricsLazyRoute
+  '/overview': typeof OverviewLazyRoute
 }
 
 export interface FileRoutesById {
@@ -104,14 +120,26 @@ export interface FileRoutesById {
   '/func-specs': typeof FuncSpecsLazyRoute
   '/issues': typeof IssuesLazyRoute
   '/metrics': typeof MetricsLazyRoute
+  '/overview': typeof OverviewLazyRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/dependencies' | '/func-specs' | '/issues' | '/metrics'
+  fullPaths:
+    | '/dependencies'
+    | '/func-specs'
+    | '/issues'
+    | '/metrics'
+    | '/overview'
   fileRoutesByTo: FileRoutesByTo
-  to: '/dependencies' | '/func-specs' | '/issues' | '/metrics'
-  id: '__root__' | '/dependencies' | '/func-specs' | '/issues' | '/metrics'
+  to: '/dependencies' | '/func-specs' | '/issues' | '/metrics' | '/overview'
+  id:
+    | '__root__'
+    | '/dependencies'
+    | '/func-specs'
+    | '/issues'
+    | '/metrics'
+    | '/overview'
   fileRoutesById: FileRoutesById
 }
 
@@ -120,6 +148,7 @@ export interface RootRouteChildren {
   FuncSpecsLazyRoute: typeof FuncSpecsLazyRoute
   IssuesLazyRoute: typeof IssuesLazyRoute
   MetricsLazyRoute: typeof MetricsLazyRoute
+  OverviewLazyRoute: typeof OverviewLazyRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -127,6 +156,7 @@ const rootRouteChildren: RootRouteChildren = {
   FuncSpecsLazyRoute: FuncSpecsLazyRoute,
   IssuesLazyRoute: IssuesLazyRoute,
   MetricsLazyRoute: MetricsLazyRoute,
+  OverviewLazyRoute: OverviewLazyRoute,
 }
 
 export const routeTree = rootRoute
@@ -142,7 +172,8 @@ export const routeTree = rootRoute
         "/dependencies",
         "/func-specs",
         "/issues",
-        "/metrics"
+        "/metrics",
+        "/overview"
       ]
     },
     "/dependencies": {
@@ -156,6 +187,9 @@ export const routeTree = rootRoute
     },
     "/metrics": {
       "filePath": "metrics.lazy.tsx"
+    },
+    "/overview": {
+      "filePath": "overview.lazy.tsx"
     }
   }
 }

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -11,7 +11,7 @@ export const Route = createRootRoute({
   loader: () => {
     if (window.location.pathname === "/") {
       redirect({
-        to: "/metrics",
+        to: "/overview",
         throw: true,
       });
     }

--- a/app/src/routes/overview.lazy.tsx
+++ b/app/src/routes/overview.lazy.tsx
@@ -1,0 +1,105 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ColumnDef } from "@tanstack/react-table";
+import { DataTable } from "@/components/table/data-table";
+import { Release, ReleasesApiResponse, RepositoryReleases } from "@/types/releases";
+
+export const Route = createLazyFileRoute("/overview")({
+  component: RouteComponent,
+});
+
+const RELEASES_URL =
+  "https://storage.googleapis.com/algokit-management-tool/site/releases/latest.json";
+
+const fetchReleases = async () => {
+  const response = await fetch(RELEASES_URL);
+  const data: ReleasesApiResponse = await response.json();
+  
+  // Transform data to add required id field and extract just repository name
+  const transformedData: RepositoryReleases[] = data.results.map((repo, index) => ({
+    ...repo,
+    id: `repo-${index}`, // Add required id field for DataTable
+    repository: repo.repository.split('/')[1] || repo.repository, // Extract just the repo name
+  }));
+  
+  return transformedData;
+};
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const ReleaseLink = ({ release }: { release: Release | null }) => {
+  if (!release) {
+    return <span className="text-gray-400">No release</span>;
+  }
+  
+  return (
+    <div className="flex flex-col">
+      <a 
+        href={release.html_url} 
+        target="_blank" 
+        rel="noopener noreferrer"
+        className="text-blue-600 hover:underline font-medium"
+      >
+        {release.tag_name}
+      </a>
+      <span className="text-xs text-gray-500">
+        {formatDate(release.published_at)}
+      </span>
+    </div>
+  );
+};
+
+const columns: ColumnDef<RepositoryReleases>[] = [
+  {
+    accessorKey: "repository",
+    header: "Repository",
+    size: 300,
+    cell: ({ row }) => (
+      <span className="font-medium">{row.getValue("repository")}</span>
+    ),
+  },
+  {
+    accessorKey: "latest_main_release",
+    header: "Latest Release",
+    size: 200,
+    cell: ({ row }) => (
+      <ReleaseLink release={row.getValue("latest_main_release")} />
+    ),
+  },
+  {
+    accessorKey: "latest_beta_release", 
+    header: "Latest Beta",
+    size: 200,
+    cell: ({ row }) => (
+      <ReleaseLink release={row.getValue("latest_beta_release")} />
+    ),
+  },
+];
+
+function RouteComponent() {
+  const { data } = useSuspenseQuery({
+    queryKey: ["releases-data"],
+    queryFn: fetchReleases,
+  });
+
+  return (
+    <div className="h-dvh p-2 px-12">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold mb-2">Repository Overview</h1>
+        <p >
+          Latest releases for AlgoKit repositories ({data?.length || 0} repositories)
+        </p>
+      </div>
+      
+      <div className="flex-1 min-h-0 shadow-sm overflow-auto bg-base rounded-sm">
+        <DataTable columnDefs={columns} data={data || []} />
+      </div>
+    </div>
+  );
+} 

--- a/app/src/types/releases.ts
+++ b/app/src/types/releases.ts
@@ -1,0 +1,26 @@
+export interface Release {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  html_url: string;
+  prerelease: boolean;
+  draft: boolean;
+  author: string;
+}
+
+export interface RepositoryReleases {
+  id: string; // Required for DataTable component
+  repository: string;
+  latest_main_release: Release | null;
+  latest_beta_release: Release | null;
+}
+
+export interface ReleasesApiResponse {
+  results: RepositoryReleases[];
+  metadata: {
+    created_at: string;
+    version: string;
+    repository_count: number;
+    source: string;
+  };
+}

--- a/backend-app/app/api/releases.py
+++ b/backend-app/app/api/releases.py
@@ -1,0 +1,40 @@
+from datetime import UTC, datetime
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+
+from app.core.config import settings
+from app.services.releases.github import get_github_releases
+from app.utils.storage import save_to_storage
+
+router = APIRouter()
+
+
+@router.get("/releases", response_model=Dict[str, Any])
+async def get_repo_releases():
+    """
+    Fetch the latest main and beta releases for all configured repositories.
+    Returns the latest main release and latest beta release for each repository.
+    """
+    try:
+        results = get_github_releases()
+        created_at = datetime.now(UTC).replace(microsecond=0).isoformat()
+        outdata = {
+            "results": results,
+            "metadata": {
+                "created_at": created_at,
+                "version": settings.VERSION,
+                "repository_count": len(settings.REPOSITORIES),
+                "source": "releases-analyzer",
+            },
+        }
+
+        cloud_storage_folder = f"{settings.GCP_BUCKET_SITE_FOLDER_NAME}/releases"
+
+        save_to_storage(
+            outdata, f"{cloud_storage_folder}/latest.json", make_public=True
+        )
+        save_to_storage(outdata, f"{cloud_storage_folder}/{created_at}.json")
+        return outdata
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend-app/app/main.py
+++ b/backend-app/app/main.py
@@ -8,6 +8,7 @@ from app.api import (
     outdated,
     pipelines,
     pull_requests,
+    releases,
     slack,
 )
 from app.core.config import settings
@@ -42,6 +43,7 @@ app.include_router(
 app.include_router(
     pull_requests.router, prefix=settings.API_V1_STR, tags=["pull_requests"]
 )
+app.include_router(releases.router, prefix=settings.API_V1_STR, tags=["releases"])
 app.include_router(slack.router, prefix=settings.API_V1_STR, tags=["slack"])
 
 

--- a/backend-app/app/services/releases/__init__.py
+++ b/backend-app/app/services/releases/__init__.py
@@ -1,0 +1,1 @@
+# Releases service package

--- a/backend-app/app/services/releases/github.py
+++ b/backend-app/app/services/releases/github.py
@@ -1,0 +1,137 @@
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from app.core.config import settings
+from app.core.logging import LoggerFactory
+from app.utils.github import get_github_token
+
+logger = LoggerFactory.get_logger(__name__)
+
+
+def get_repo_releases(repo_name: str, token: str) -> List[Dict[str, Any]]:
+    """Fetch releases for a specific repository."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+    url = f"https://api.github.com/repos/{settings.GITHUB_ORG}/{repo_name}/releases"
+    all_releases = []
+    page = 1
+
+    while True:
+        response = requests.get(f"{url}?page={page}&per_page=100", headers=headers)
+        if response.status_code != 200:
+            logger.error(
+                f"Error fetching releases for {settings.GITHUB_ORG}/{repo_name}: {response.status_code}"
+            )
+            break
+
+        releases = response.json()
+        if not releases:
+            break
+
+        all_releases.extend(releases)
+        page += 1
+        # Adding a delay to avoid rate limiting
+        time.sleep(0.5)
+
+    return all_releases
+
+
+def classify_release(release: Dict[str, Any]) -> str:
+    """Classify a release as main or beta based on tag name and prerelease flag."""
+    tag_name = release.get("tag_name", "").lower()
+    is_prerelease = release.get("prerelease", False)
+
+    # Beta release indicators
+    beta_indicators = ["beta", "alpha", "rc", "pre", "dev"]
+
+    if is_prerelease or any(indicator in tag_name for indicator in beta_indicators):
+        return "beta"
+    else:
+        return "main"
+
+
+def get_latest_releases_for_repo(
+    repo_name: str, token: str
+) -> Dict[str, Optional[Dict[str, Any]]]:
+    """Get the latest main and beta releases for a specific repository."""
+    releases = get_repo_releases(repo_name, token)
+
+    # Sort releases by published_at in descending order (newest first) to ensure
+    # we get the actual latest releases regardless of API default ordering
+    releases.sort(key=lambda r: r.get("published_at", ""), reverse=True)
+
+    latest_main = None
+    latest_beta = None
+
+    for release in releases:
+        if release.get("draft", False):
+            continue  # Skip draft releases
+
+        release_type = classify_release(release)
+
+        if release_type == "main" and latest_main is None:
+            latest_main = {
+                "tag_name": release["tag_name"],
+                "name": release["name"],
+                "published_at": release["published_at"],
+                "html_url": release["html_url"],
+                "prerelease": release["prerelease"],
+                "draft": release["draft"],
+                "author": release["author"]["login"] if release.get("author") else None,
+            }
+        elif release_type == "beta" and latest_beta is None:
+            latest_beta = {
+                "tag_name": release["tag_name"],
+                "name": release["name"],
+                "published_at": release["published_at"],
+                "html_url": release["html_url"],
+                "prerelease": release["prerelease"],
+                "draft": release["draft"],
+                "author": release["author"]["login"] if release.get("author") else None,
+            }
+
+        # Break early if we found both
+        if latest_main and latest_beta:
+            break
+
+    return {"main": latest_main, "beta": latest_beta}
+
+
+def get_github_releases() -> List[Dict[str, Any]]:
+    """
+    Fetches the latest main and beta releases from all configured repositories.
+    """
+    try:
+        token = get_github_token()
+        all_releases = []
+
+        for repo in settings.REPOSITORIES:
+            repo_name = repo["name"]
+            logger.info(f"Fetching releases for {settings.GITHUB_ORG}/{repo_name}")
+
+            releases = get_latest_releases_for_repo(repo_name, token)
+
+            repo_releases = {
+                "repository": f"{settings.GITHUB_ORG}/{repo_name}",
+                "latest_main_release": releases["main"],
+                "latest_beta_release": releases["beta"],
+            }
+
+            all_releases.append(repo_releases)
+
+        return all_releases
+
+    except Exception as e:
+        logger.error(f"Error fetching releases: {str(e)}")
+        raise e
+
+
+if __name__ == "__main__":
+    print("Testing releases service...")
+    releases = get_github_releases()
+    print(f"Found releases for {len(releases)} repositories")


### PR DESCRIPTION
This PR adds comprehensive GitHub releases tracking with both backend API and frontend display capabilities.

### Changes
- **Backend**: New `/releases` API endpoint that fetches and categorizes latest main and beta releases from configured repositories
- **Frontend**: New "Overview" page displaying releases in a sortable table with clickable GitHub links
- **Navigation**: Updated to make Overview the default landing page

### Features
- Tracks both stable and beta releases for all AlgoKit repositories
- Displays formatted release dates and repository counts
- Clickable release links that open directly on GitHub